### PR TITLE
Remove numpy object deprecated in 1.20

### DIFF
--- a/das2/pycdf/__init__.py
+++ b/das2/pycdf/__init__.py
@@ -3555,8 +3555,8 @@ class _Hyperslice(object):
         self.counts = numpy.empty((self.dims,), dtype=numpy.int32)
         self.counts.fill(1)
         self.intervals = [1] * self.dims
-        self.degen = numpy.zeros(self.dims, dtype=numpy.bool)
-        self.rev = numpy.zeros(self.dims, dtype=numpy.bool)
+        self.degen = numpy.zeros(self.dims, dtype=bool)
+        self.rev = numpy.zeros(self.dims, dtype=bool)
         #key is:
         #1. a single value (integer or slice object) if called 1D
         #2. a tuple (of integers and/or slice objects) if called nD
@@ -3796,7 +3796,7 @@ class _Hyperslice(object):
     def check_well_formed(data):
         """Checks if input data is well-formed, regular array"""
         d = numpy.asanyarray(data)
-        if d.dtype == numpy.object: #this is probably going to be bad
+        if d.dtype == object: #this is probably going to be bad
             try:
                 len(d.flat[0])
             except TypeError: #at least it's not a list


### PR DESCRIPTION
Found issues related to numpy. Versions past 1.20 can have an issue using numpy.object and numpy.bool.

Changes fix issue noted in #9 when running `make examples`