### PR TITLE
Works with das2C 3.0-pre1

### DIFF
--- a/buildfiles/Linux.mak
+++ b/buildfiles/Linux.mak
@@ -91,13 +91,14 @@ examples:
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/c_module/galileo_pws_e-survey.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/c_module/juno_hfwbr_cdf.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex01_source_queries.py
+	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex02_galileo_pws_spectra.py	
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex03_cassini_rpws_multimode.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex04_voyager_pws_query_by_time.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex08_juno_waves_wfrm_to_cdf.py
-	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex10_manual_datasets.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex09_cassini_fce_ephem_ticks.py 2017-02-01
+	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex10_manual_datasets.py
 	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex11_catalog_listings.py
-	env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex02_galileo_pws_spectra.py
+	
 
 # TODO: Revive this
 # env PYTHONPATH=$(PWD)/$(BD) python$(PYVER) examples/ex05_mex_marsis_query_by_angle.py

--- a/buildfiles/pypi/build_wheels.md
+++ b/buildfiles/pypi/build_wheels.md
@@ -26,7 +26,7 @@ cd ..\
 
 rem build das2C
 cd das2C
-git checkout tags/v2.3.0
+git checkout tags/v3.0-pre1
 set VCPKG_ROOT=C:\Users\you\git\vcpkg # Adjust as needed
 set LIBRARY_INC=%VCPKG_ROOT%\installed\x64-windows-static\include
 set LIBRARY_LIB=%VCPKG_ROOT%\installed\x64-windows-static\lib
@@ -37,7 +37,7 @@ cd ..\
 
 rem build das2py (reuses VCPKG_ROOT setting from above)
 cd das2py
-git checkout tags/v2.3.0  # Or stay on main if testing
+git checkout tags/v3.0-pre1  # Or stay on main if testing
 python -m pip install numpy
 python -m pip install wheel
 python -m pip install --upgrade build
@@ -57,4 +57,6 @@ rem OTHER TESTS HERE
 rem upload to pypi
 cd das2py
 python -m twine upload dist/*
+username: __token__
+password: (the 170+ character token value that you saved somewhere)
 ```

--- a/das2/dataset.py
+++ b/das2/dataset.py
@@ -1495,7 +1495,7 @@ class Dataset(object):
 # ########################################################################### #
 # das2C wrapper to high level interface conversion functions
 
-def _mk_prop_from_raw(tProp):
+def mk_prop_from_raw(tProp):
 	"""Make a property dictionary value given a :mod:_das2 property string
 
 	Low level properties are the tuples:
@@ -1722,7 +1722,7 @@ def _init_dim_from_raw(dim, dRawDs, dRawDim, bMask=False):
 		elif sVar == 'props':
 			dRawProps = dRawDim['props']
 			for sProp in dRawProps:
-				dim.props[sProp] = _mk_prop_from_raw(dRawProps[sProp])
+				dim.props[sProp] = mk_prop_from_raw(dRawProps[sProp])
 		else:
 			sExp = dRawDim[sVar]['expression']
 			sUnits = dRawDim[sVar]['units']
@@ -1745,7 +1745,7 @@ def ds_from_raw(dRawDs):
 	ds = Dataset(dRawDs['id'], dRawDs['group'])
 
 	for sProp in dRawDs['props']:
-		ds.props[sProp] = _mk_prop_from_raw(dRawDs['props'][sProp])
+		ds.props[sProp] = mk_prop_from_raw(dRawDs['props'][sProp])
 
 	ds.shape = dRawDs['shape']
 

--- a/das2/streamsrc.py
+++ b/das2/streamsrc.py
@@ -367,6 +367,7 @@ class HttpStreamSrc(Source):
 			self.lBadBase = []
 
 		# Change this up when the definition changes
+		dHdr = None
 		lDs = None
 		for i in range(0, len(dProto['base_urls'])):
 			sBaseUrl = dProto['base_urls'][i]
@@ -403,7 +404,16 @@ class HttpStreamSrc(Source):
 			lOut = []
 			for ds in lDs:
 				lOut.append(ds_from_raw(ds))
-			return lOut
+
+			# Adapt the header properties 
+			dRawProps = dHdr['props']
+			dDictProps = {}
+			for sProp in dRawProps:
+				dDictProps[sProp] = mk_prop_from_raw(dRawProps[sProp])
+			
+			dHdr['props'] = dDictProps    # Now replace them
+
+			return (dHdr, lOut)
 
 		raise SourceError(sUrl, "Unable to retrieve data")
 

--- a/das2/xsd/das-basic-doc-ns-v3.0.xsd
+++ b/das2/xsd/das-basic-doc-ns-v3.0.xsd
@@ -109,6 +109,7 @@ version 3.0, release candiate 2, 2024-05-27
   <xs:restriction base="xs:string" >
     <!-- Anything but a pipe, higher level parsing may disqualify many patterns -->
     <xs:pattern value="([ -{]|[}~];)+" />
+    <xs:pattern value="\\n" />
   </xs:restriction>
 </xs:simpleType>
 
@@ -132,8 +133,8 @@ version 3.0, release candiate 2, 2024-05-27
 
 <!-- Coordinate Frames =================================================== -->
 
-<!-- These are independent of any particular values and assign DIRECTIONALTY
-     ONLY!  Frame components have no units.  These are not to be confused with
+<!-- These are independent of any particular values and often assign directionality
+     only.  Frame components have no units.  These are not to be confused with
      the "axis" values from <coord>.  The attribute "axis" is a graphical display
      directive and refers to a display axis, not a physical axis.  
 
@@ -141,18 +142,13 @@ version 3.0, release candiate 2, 2024-05-27
      attributes of <coord>
 -->
 
-<xs:complexType name="FrameDirection">
-  <xs:attribute name="name"  type="VarName" use="required" />
-</xs:complexType>
-
 <xs:complexType name="Frame" >
   <xs:sequence>
     <xs:element name="properties" type="Properties" minOccurs="0" maxOccurs="1"/>
-    <xs:element name="dir" type="FrameDirection" minOccurs="1" maxOccurs="9" />
   </xs:sequence>
   <xs:attribute name="name" type="StructName" use="required"/>
-  <xs:attribute name="type" type="VarName" use="required" />
   <xs:attribute name="inertial" type="Bool"/>
+  <xs:attribute name="body" type="xs:string" />
 </xs:complexType>
 
 <!-- Extensions ========================================================== -->
@@ -220,7 +216,7 @@ version 3.0, release candiate 2, 2024-05-27
 -->
 <xs:simpleType name="PlotDirection">
   <xs:restriction base="xs:string">
-    <xs:pattern value="[xyzρrθφt](;[xyzρrθφt])*" />
+    <xs:pattern value="[xyzρrθφt](;[xyzρrθφat])*" />
     <!-- ρ: radius cylindrical -->
     <!-- r: radius spherical & polar -->
     <!-- θ: polar angle -->
@@ -228,7 +224,6 @@ version 3.0, release candiate 2, 2024-05-27
     <!-- t: for movies, not time on a space axis -->
   </xs:restriction>
 </xs:simpleType>
-
 
 <!-- The Index space definition for this dataset.
 
@@ -283,6 +278,7 @@ version 3.0, release candiate 2, 2024-05-27
   </xs:restriction>
 </xs:simpleType>
 
+
 <xs:simpleType name="Star" final="restriction">
   <xs:restriction base="xs:string">
     <xs:enumeration value="*" />
@@ -323,13 +319,13 @@ version 3.0, release candiate 2, 2024-05-27
      or just some information (string) -->
 <xs:simpleType name="Semantic">
   <xs:restriction base="xs:string">
-      <xs:pattern value="bool|datetime|int|real|string" />
+      <xs:pattern value="bool|datetime|int|real|string|pixel" />
    </xs:restriction>
 </xs:simpleType>
 
 <!-- What kind of arrays and values in memory should be used for this item
      Since some languages don't support unsigned types and can use the next
-     largger signed type
+     larger signed type
 -->
 <xs:simpleType name="Storage">
   <xs:restriction base="xs:string">
@@ -413,11 +409,14 @@ version 3.0, release candiate 2, 2024-05-27
 </xs:simpleType>
 
 <xs:complexType name="ScalarVar" >
-  <xs:choice>
-    <xs:element name="values" type="Values" />
-    <xs:element name="sequence" type="Sequence" />
-    <xs:element name="packet" type="Packet" />
-  </xs:choice>
+  <xs:sequence>
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="values" type="Values" />
+      <xs:element name="sequence" type="Sequence" />
+      <xs:element name="packet" type="Packet" />
+    </xs:choice>
+  </xs:sequence>
   <xs:attribute name="use"      type="VarRole" default="center" />
   <xs:attribute name="units"    type="xs:token" use="required" />
   <xs:attribute name="storage"  type="Storage" />
@@ -428,23 +427,26 @@ version 3.0, release candiate 2, 2024-05-27
 
 <!-- Vectors, Inherit from scalars and add elements ======== -->
 
-<xs:complexType name="VecComponent">
-  <xs:attribute name="dir"  type="VarName" use="required" />
-  <xs:attribute name="units" type="xs:token" />
-</xs:complexType>
+<xs:simpleType  name="ComponentList">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-2](;[0-2]){0,2}" />
+  </xs:restriction>
+</xs:simpleType>
 
-<xs:simpleType name="VectorClass">
+<xs:simpleType name="ComponentSystem">
   <xs:restriction base="xs:string">
     <xs:enumeration value="cartesian" />
     <xs:enumeration value="polar" />
     <xs:enumeration value="spherical" />
+    <xs:enumeration value="centric" />
+    <xs:enumeration value="detic" />
     <!-- More?? -->
   </xs:restriction>
 </xs:simpleType>
 
 <xs:complexType name="VectorVar" >
   <xs:sequence>
-    <xs:element name="component" type="VecComponent" minOccurs="1" maxOccurs="3" />
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
     <xs:choice>
       <xs:element name="values" type="Values" />
       <xs:element name="sequence" type="Sequence" />
@@ -456,8 +458,9 @@ version 3.0, release candiate 2, 2024-05-27
   <xs:attribute name="semantic" type="Semantic" use="required" />
   <xs:attribute name="storage"  type="Storage" />
   <xs:attribute name="index"    type="VarIndexShape" use="required" />
-  <!-- deprecated -->
-  <xs:attribute name="vecClass" type="VectorClass" />
+  <xs:attribute name="system"   type="ComponentSystem" default="cartesian"/>
+  <xs:attribute name="components" type="ComponentList" use="required" />
+  <xs:attribute name="refSurface"  type="xs:string" /> <!-- 0 = SPICE default for frame body -->
 </xs:complexType>
 
 <!-- Physical Dimensions ================================================= -->
@@ -465,16 +468,30 @@ version 3.0, release candiate 2, 2024-05-27
 <xs:complexType name="CoordDim">
   <xs:sequence>
     <xs:element name="properties" type="Properties" minOccurs="0"/>
-    
+
     <xs:choice minOccurs="1" maxOccurs="unbounded">
-      <xs:element name="scalar" type="ScalarVar" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="scalar" type="ScalarVar" />
       <xs:element name="vector" type="VectorVar" />
     </xs:choice>
 
   </xs:sequence>
   <xs:attribute name="physDim"  type="PhysDimName"   use="required"/>
-  <xs:attribute name="axis"     type="PlotDirection" use="required"/>
-  <xs:attribute name="frame"    type="StructName" />
+
+  <!-- Coordinate dims should have names, and if there is more the one for the same
+       physical dimension (say space in two different coordinate systems) then names
+       are a must -->
+  <xs:attribute name="name"     type="StructName" />
+
+  <!-- The use of axes is required for primary coordinates -->
+  <xs:attribute name="axis"     type="PlotDirection"/>
+
+  <!-- The use of annotation is recommened for secondard coordinates -->
+  <xs:attribute name="annotation" type="PlotDirection"/>  
+
+  <xs:attribute name="frame"    type="StructName"   />
+  <!-- No need to provide for single component coordinates, if they are
+       vectors, put them together as a vector so that they can be transform
+       as a vector, using systems like SPICE -->
   <!-- <xs:attribute name="dir" type="VarName"  /> -->
 </xs:complexType>
 
@@ -575,7 +592,7 @@ version 3.0, release candiate 2, 2024-05-27
     CDF ISTP metadata model. -cwp 2020-07-17
     -->
     
-    <xs:element name="data" type="DataDim" minOccurs="0" maxOccurs="unbounded" />
+    <xs:element name="data"    type="DataDim"      minOccurs="0" maxOccurs="unbounded" />
     <xs:element name="extData" type="ExtendedData" minOccurs="0" maxOccurs="unbounded" />
 
   </xs:sequence>

--- a/das2/xsd/das-basic-stream-ns-v3.0.xsd
+++ b/das2/xsd/das-basic-stream-ns-v3.0.xsd
@@ -121,8 +121,8 @@
 
 <!-- Coordinate Frames =================================================== -->
 
-<!-- These are independent of any particular values and assign DIRECTIONALTY
-     ONLY!  Frame components have no units.  These are not to be confused with
+<!-- These are independent of any particular values and often assign directionality
+     only.  Frame components have no units.  These are not to be confused with
      the "axis" values from <coord>.  The attribute "axis" is a graphical display
      directive and refers to a display axis, not a physical axis.  
 
@@ -130,18 +130,13 @@
      attributes of <coord>
 -->
 
-<xs:complexType name="FrameDirection">
-  <xs:attribute name="name"  type="VarName" use="required" />
-</xs:complexType>
-
 <xs:complexType name="Frame" >
   <xs:sequence>
     <xs:element name="properties" type="Properties" minOccurs="0" maxOccurs="1"/>
-    <xs:element name="dir" type="FrameDirection" minOccurs="1" maxOccurs="9" />
   </xs:sequence>
   <xs:attribute name="name" type="StructName" use="required"/>
-  <xs:attribute name="type" type="VarName" use="required" />
   <xs:attribute name="inertial" type="Bool"/>
+  <xs:attribute name="body" type="xs:string" />
 </xs:complexType>
 
 <!-- Extensions ========================================================== -->
@@ -154,8 +149,8 @@
 <xs:complexType name="Extension" mixed="true">
   <xs:sequence>
     <xs:choice>
-      <!-- Can extend with other elements here, but they can't be from this namespace -->
-      <xs:any namespace="##other" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- Can extend with other elements here, but they can't have a namespace -->
+      <xs:any namespace="##local" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
     </xs:choice>
   </xs:sequence>
 
@@ -209,7 +204,7 @@
 -->
 <xs:simpleType name="PlotDirection">
   <xs:restriction base="xs:string">
-    <xs:pattern value="[xyzρrθφt](;[xyzρrθφt])*" />
+    <xs:pattern value="[xyzρrθφt](;[xyzρrθφat])*" />
     <!-- ρ: radius cylindrical -->
     <!-- r: radius spherical & polar -->
     <!-- θ: polar angle -->
@@ -312,7 +307,7 @@
      or just some information (string) -->
 <xs:simpleType name="Semantic">
   <xs:restriction base="xs:string">
-      <xs:pattern value="bool|datetime|int|real|string" />
+      <xs:pattern value="bool|datetime|int|real|string|pixel" />
    </xs:restriction>
 </xs:simpleType>
 
@@ -330,7 +325,7 @@
 <xs:simpleType name="EncodingType">
   <xs:restriction base="xs:string">
     <xs:pattern 
-      value="byte|ubyte|BEint|BEuint|BEreal|LEint|LEuint|LEreal|utf8|none" />
+      value="byte|ubyte|BEint|BEuint|BEreal|LEint|LEuint|LEreal|utf8|png|jpeg|none" />
    </xs:restriction>
 </xs:simpleType>
 
@@ -420,11 +415,14 @@
 </xs:simpleType>
 
 <xs:complexType name="ScalarVar" >
-  <xs:choice>
-    <xs:element name="values" type="Values" />
-    <xs:element name="sequence" type="Sequence" />
-    <xs:element name="packet" type="Packet" />
-  </xs:choice>
+  <xs:sequence>
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="values" type="Values" />
+      <xs:element name="sequence" type="Sequence" />
+      <xs:element name="packet" type="Packet" />
+    </xs:choice>
+  </xs:sequence>
   <xs:attribute name="use"      type="VarRole" default="center" />
   <xs:attribute name="units"    type="xs:token" use="required" />
   <xs:attribute name="storage"  type="Storage" />
@@ -435,23 +433,26 @@
 
 <!-- Vectors, Inherit from scalars and add elements ======== -->
 
-<xs:complexType name="VecComponent">
-  <xs:attribute name="dir"  type="VarName" use="required" />
-  <xs:attribute name="units" type="xs:token" />
-</xs:complexType>
+<xs:simpleType  name="ComponentList">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-2](;[0-2]){0,2}" />
+  </xs:restriction>
+</xs:simpleType>
 
-<xs:simpleType name="VectorClass">
+<xs:simpleType name="ComponentSystem">
   <xs:restriction base="xs:string">
     <xs:enumeration value="cartesian" />
     <xs:enumeration value="polar" />
     <xs:enumeration value="spherical" />
+    <xs:enumeration value="centric" />
+    <xs:enumeration value="detic" />
     <!-- More?? -->
   </xs:restriction>
 </xs:simpleType>
 
 <xs:complexType name="VectorVar" >
   <xs:sequence>
-    <xs:element name="component" type="VecComponent" minOccurs="1" maxOccurs="3" />
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
     <xs:choice>
       <xs:element name="values" type="Values" />
       <xs:element name="sequence" type="Sequence" />
@@ -463,8 +464,9 @@
   <xs:attribute name="semantic" type="Semantic" use="required" />
   <xs:attribute name="storage"  type="Storage" />
   <xs:attribute name="index"    type="VarIndexShape" use="required" />
-  <!-- deprecated -->
-  <xs:attribute name="vecClass" type="VectorClass" />
+  <xs:attribute name="system"   type="ComponentSystem" default="cartesian"/>
+  <xs:attribute name="components" type="ComponentList" use="required" />
+  <xs:attribute name="refSurface"  type="xs:string" /> <!-- 0 = SPICE default for frame body -->
 </xs:complexType>
 
 <!-- Physical Dimensions ================================================= -->
@@ -473,16 +475,29 @@
   <xs:sequence>
     <xs:element name="properties" type="Properties" minOccurs="0"/>
 
-    <!-- For v3.0/basic only allow scalar types in coordinates -->
-    <!-- <xs:choice minOccurs="1" maxOccurs="unbounded">  -->
-    <xs:element name="scalar" type="ScalarVar" minOccurs="1" maxOccurs="unbounded"/>
-    <!-- <xs:element name="vector" type="VectorVar" /> -->
-    <!-- </xs:choice> -->
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
+      <xs:element name="scalar" type="ScalarVar" />
+      <xs:element name="vector" type="VectorVar" />
+    </xs:choice>
 
   </xs:sequence>
   <xs:attribute name="physDim"  type="PhysDimName"   use="required"/>
-  <xs:attribute name="axis"     type="PlotDirection" use="required"/>
-  <xs:attribute name="frame"    type="StructName" />
+
+  <!-- Coordinate dims should have names, and if there is more the one for the same
+       physical dimension (say space in two different coordinate systems) then names
+       are a must -->
+  <xs:attribute name="name"     type="StructName" />
+
+  <!-- The use of axes is required for primary coordinates -->
+  <xs:attribute name="axis"     type="PlotDirection"/>
+
+  <!-- The use of annotation is recommened for secondard coordinates -->
+  <xs:attribute name="annotation" type="PlotDirection"/>  
+
+  <xs:attribute name="frame"    type="StructName"   />
+  <!-- No need to provide for single component coordinates, if they are
+       vectors, put them together as a vector so that they can be transform
+       as a vector, using systems like SPICE -->
   <!-- <xs:attribute name="dir" type="VarName"  /> -->
 </xs:complexType>
 
@@ -583,7 +598,7 @@
     CDF ISTP metadata model. -cwp 2020-07-17
     -->
     
-    <xs:element name="data" type="DataDim" minOccurs="0" maxOccurs="unbounded" />
+    <xs:element name="data"    type="DataDim"      minOccurs="0" maxOccurs="unbounded" />
     <xs:element name="extData" type="ExtendedData" minOccurs="0" maxOccurs="unbounded" />
 
   </xs:sequence>

--- a/das2/xsd/das-basic-stream-v3.0.xsd
+++ b/das2/xsd/das-basic-stream-v3.0.xsd
@@ -121,8 +121,8 @@
 
 <!-- Coordinate Frames =================================================== -->
 
-<!-- These are independent of any particular values and assign DIRECTIONALTY
-     ONLY!  Frame components have no units.  These are not to be confused with
+<!-- These are independent of any particular values and often assign directionality
+     only.  Frame components have no units.  These are not to be confused with
      the "axis" values from <coord>.  The attribute "axis" is a graphical display
      directive and refers to a display axis, not a physical axis.  
 
@@ -130,18 +130,13 @@
      attributes of <coord>
 -->
 
-<xs:complexType name="FrameDirection">
-  <xs:attribute name="name"  type="VarName" use="required" />
-</xs:complexType>
-
 <xs:complexType name="Frame" >
   <xs:sequence>
     <xs:element name="properties" type="Properties" minOccurs="0" maxOccurs="1"/>
-    <xs:element name="dir" type="FrameDirection" minOccurs="1" maxOccurs="9" />
   </xs:sequence>
   <xs:attribute name="name" type="StructName" use="required"/>
-  <xs:attribute name="type" type="VarName" use="required" />
   <xs:attribute name="inertial" type="Bool"/>
+  <xs:attribute name="body" type="xs:string" />
 </xs:complexType>
 
 <!-- Extensions ========================================================== -->
@@ -209,7 +204,7 @@
 -->
 <xs:simpleType name="PlotDirection">
   <xs:restriction base="xs:string">
-    <xs:pattern value="[xyzρrθφt](;[xyzρrθφt])*" />
+    <xs:pattern value="[xyzρrθφt](;[xyzρrθφat])*" />
     <!-- ρ: radius cylindrical -->
     <!-- r: radius spherical & polar -->
     <!-- θ: polar angle -->
@@ -312,7 +307,7 @@
      or just some information (string) -->
 <xs:simpleType name="Semantic">
   <xs:restriction base="xs:string">
-      <xs:pattern value="bool|datetime|int|real|string" />
+      <xs:pattern value="bool|datetime|int|real|string|pixel" />
    </xs:restriction>
 </xs:simpleType>
 
@@ -330,7 +325,7 @@
 <xs:simpleType name="EncodingType">
   <xs:restriction base="xs:string">
     <xs:pattern 
-      value="byte|ubyte|BEint|BEuint|BEreal|LEint|LEuint|LEreal|utf8|none" />
+      value="byte|ubyte|BEint|BEuint|BEreal|LEint|LEuint|LEreal|utf8|png|jpeg|none" />
    </xs:restriction>
 </xs:simpleType>
 
@@ -380,7 +375,7 @@
 
       <!-- Since values elements have a natural end point, no terminator
         is needed for the last value -->
-      <xs:attribute name="valTerm" type="Terminator" default=" " />
+      <xs:attribute name="valSep" type="Terminator" default=";" />
     </xs:extension>
   </xs:simpleContent>
 </xs:complexType>
@@ -420,11 +415,14 @@
 </xs:simpleType>
 
 <xs:complexType name="ScalarVar" >
-  <xs:choice>
-    <xs:element name="values" type="Values" />
-    <xs:element name="sequence" type="Sequence" />
-    <xs:element name="packet" type="Packet" />
-  </xs:choice>
+  <xs:sequence>
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="values" type="Values" />
+      <xs:element name="sequence" type="Sequence" />
+      <xs:element name="packet" type="Packet" />
+    </xs:choice>
+  </xs:sequence>
   <xs:attribute name="use"      type="VarRole" default="center" />
   <xs:attribute name="units"    type="xs:token" use="required" />
   <xs:attribute name="storage"  type="Storage" />
@@ -435,23 +433,26 @@
 
 <!-- Vectors, Inherit from scalars and add elements ======== -->
 
-<xs:complexType name="VecComponent">
-  <xs:attribute name="dir"  type="VarName" use="required" />
-  <xs:attribute name="units" type="xs:token" />
-</xs:complexType>
+<xs:simpleType  name="ComponentList">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-2](;[0-2]){0,2}" />
+  </xs:restriction>
+</xs:simpleType>
 
-<xs:simpleType name="VectorClass">
+<xs:simpleType name="ComponentSystem">
   <xs:restriction base="xs:string">
     <xs:enumeration value="cartesian" />
     <xs:enumeration value="polar" />
     <xs:enumeration value="spherical" />
+    <xs:enumeration value="centric" />
+    <xs:enumeration value="detic" />
     <!-- More?? -->
   </xs:restriction>
 </xs:simpleType>
 
 <xs:complexType name="VectorVar" >
   <xs:sequence>
-    <xs:element name="component" type="VecComponent" minOccurs="1" maxOccurs="3" />
+    <xs:element name="properties" type="Properties" minOccurs="0"/>
     <xs:choice>
       <xs:element name="values" type="Values" />
       <xs:element name="sequence" type="Sequence" />
@@ -463,8 +464,9 @@
   <xs:attribute name="semantic" type="Semantic" use="required" />
   <xs:attribute name="storage"  type="Storage" />
   <xs:attribute name="index"    type="VarIndexShape" use="required" />
-  <!-- deprecated -->
-  <xs:attribute name="vecClass" type="VectorClass" />
+  <xs:attribute name="system"   type="ComponentSystem" default="cartesian"/>
+  <xs:attribute name="components" type="ComponentList" use="required" />
+  <xs:attribute name="refSurface"  type="xs:string" /> <!-- 0 = SPICE default for frame body -->
 </xs:complexType>
 
 <!-- Physical Dimensions ================================================= -->
@@ -474,17 +476,28 @@
     <xs:element name="properties" type="Properties" minOccurs="0"/>
 
     <xs:choice minOccurs="1" maxOccurs="unbounded">
-      <xs:element name="scalar" type="ScalarVar" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="scalar" type="ScalarVar" />
       <xs:element name="vector" type="VectorVar" />
     </xs:choice>
 
   </xs:sequence>
   <xs:attribute name="physDim"  type="PhysDimName"   use="required"/>
-  <xs:attribute name="axis"     type="PlotDirection" use="required"/>
-  <xs:attribute name="frame"    type="StructName" />
+
+  <!-- Coordinate dims should have names, and if there is more the one for the same
+       physical dimension (say space in two different coordinate systems) then names
+       are a must -->
+  <xs:attribute name="name"     type="StructName" />
+
+  <!-- The use of axes is required for primary coordinates -->
+  <xs:attribute name="axis"     type="PlotDirection"/>
+
+  <!-- The use of annotation is recommened for secondard coordinates -->
+  <xs:attribute name="annotation" type="PlotDirection"/>  
+
+  <xs:attribute name="frame"    type="StructName"   />
   <!-- No need to provide for single component coordinates, if they are
        vectors, put them together as a vector so that they can be transform
-       as a vector, using things like SPICE -->
+       as a vector, using systems like SPICE -->
   <!-- <xs:attribute name="dir" type="VarName"  /> -->
 </xs:complexType>
 

--- a/examples/c_module/galileo_pws_e-survey.py
+++ b/examples/c_module/galileo_pws_e-survey.py
@@ -217,7 +217,7 @@ def main(argv):
 	cbar.set_label("log(%s)"%unitsZ)
 	pyplot.xlabel(unitsX)
 	pyplot.ylabel("log(%s)"%unitsY)
-	pyplot.title(ds['props']['title'][1])
+	pyplot.title(dHdr['props']['title'][1])
 	pyplot.savefig('galileo_pws_e-survey.png')
 
 

--- a/examples/ex01_source_queries.py
+++ b/examples/ex01_source_queries.py
@@ -75,7 +75,7 @@ print(src.info())
 
 dQuery = { 'time':('2008-223T09:06', '2008-223T09:13'), 
            'frequency':{'band':'80 kHz'}  }
-lDatasets = src.get(dQuery)
+streamHdr, lDatasets = src.get(dQuery)
 
 # Print dataset info. Actually using the datasets returned via these queries
 # is the subject of subsequent examples

--- a/examples/ex02_galileo_pws_spectra.py
+++ b/examples/ex02_galileo_pws_spectra.py
@@ -22,7 +22,7 @@ src = das2.get_source(sId)
 # Get data from the source.  Note, if no parameters are specifed the default
 # range and resolution in the source definition will be used
 print("Reading default example Galileo PWS E-Survey data...")
-lDs = src.get()
+(header, lDs) = src.get()
 ds = lDs[0]     # simple example, real code should check dataset list size
 print("%d datasets returned"%len(lDs))
 
@@ -83,6 +83,6 @@ ax0.set_xlabel(das2.mpl.range_label(time) )
 ax0.set_ylabel(das2.mpl.label(freq.props['label']))
 cbar.set_label(das2.mpl.label(specDens.props['label']) )
 
-ax0.set_title(das2.mpl.label(ds.props['title']) )
+ax0.set_title(das2.mpl.label(header['props']['title']) )
 
 pyplot.savefig('ex02_galileo_pws_spectra.png')

--- a/examples/ex03_cassini_rpws_multimode.py
+++ b/examples/ex03_cassini_rpws_multimode.py
@@ -20,7 +20,7 @@ print("Getting data source definition for %s"%sId)
 src = das2.get_source(sId)
 
 print("Reading default example Cassini RPWS E-Survey data...")
-lDs = src.get()
+(hdr, lDs) = src.get()
 
 # Combining multiple spectra into one overall array set
 print("Combining arrays...")

--- a/examples/ex04_voyager_pws_query_by_time.py
+++ b/examples/ex04_voyager_pws_query_by_time.py
@@ -27,7 +27,8 @@ else:
 sId = 'site:/uiowa/voyager/1/pws/specanalyzer-4s-efield/das2'
 src = das2.get_source(sId)
 
-ds = src.get({'time':subset})[0]
+(hdr,lDs) = src.get({'time':subset})
+ds = lDs[0]
 print(ds)
 
 time = ds['time']

--- a/examples/ex08_juno_waves_wfrm_to_cdf.py
+++ b/examples/ex08_juno_waves_wfrm_to_cdf.py
@@ -34,11 +34,12 @@ def test_load_data(tBeg, tEnd, SrcId):
    try:
       src = das2.get_source(SrcId)
       dQuery = {'time':(tBeg, tEnd), 'hfr_i':True}
-      dsReal = src.get(dQuery)[0]
-	
+      (hdr, lDs) = src.get(dQuery)
+      dsReal = lDs[0]
+   
    except (IndexError):
       return False
-	
+   
    else:
       return True
 
@@ -51,12 +52,14 @@ def getIQ(sSrcId, sBeg, sEnd):
 
    print("Getting Reals from %s to %s"%(sBeg, sEnd))
    dQuery = {'time':(sBeg, sEnd), 'hfr_i':True}
-   dsReal = src.get(dQuery)[0]
+   (hdr, lDs) = src.get(dQuery)
+   dsReal = lDs[0]
    print(dsReal)
 
    print("Getting Imaginary from %s to %s"%(sBeg, sEnd))
    dQuery = {'time':(sBeg, sEnd), 'hfr_q':True}
-   dsImg = src.get(dQuery)[0]
+   (hdr, lDs) = src.get(dQuery)
+   dsImg = lDs[0]
    #print(dsImg)
 
    return (dsReal, dsImg, src)

--- a/examples/ex09_cassini_fce_ephem_ticks.py
+++ b/examples/ex09_cassini_fce_ephem_ticks.py
@@ -52,7 +52,8 @@ def dayLabels(sDay, sEphemSrc):
 	
 	# Here I'm using the Coordinate subset query shortcut as described
 	# in "shortcuts" section of the help above
-	dsEphem = ephem_src.get({'time':(str(dtBeg), str(dtEnd), 60*60*4)})[0]
+	(hdr, lDs) = ephem_src.get({'time':(str(dtBeg), str(dtEnd), 60*60*4)})
+	dsEphem = lDs[0]
 	print(dsEphem)             # Print dev info about the dataset
 	
 	
@@ -103,7 +104,8 @@ def main(lArgs):
 	print(fce_src.info())      # Print dev info about the source
 	
 	
-	dsFce = fce_src.get({'time':(sBeg, sEnd)})[0]
+	hdrFce, lDs = fce_src.get({'time':(sBeg, sEnd)})
+	dsFce = lDs[0]
 	print(dsFce)             # Print dev info about the dataset
 
 
@@ -143,7 +145,8 @@ def main(lArgs):
 	
 	# das2.mpl module provides das2 -to-> mpl text formatting
 	ax0.set_ylabel(das2.mpl.label(dsFce['Fce'].props['label']))
-	ax0.set_title(das2.mpl.label(dsFce.props['title']))
+	print(hdrFce['props']['title'])
+	ax0.set_title(das2.mpl.label(hdrFce['props']['title']))
 	
 	pyplot.savefig('cas_mag_fce_%s.png'%sDate)
 	

--- a/scripts/das_verify
+++ b/scripts/das_verify
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import sys
 import das2.verify
 
-das2.verify.main()
+nRet = das2.verify.main()
+if nRet != 0:
+	sys.exit(nRet)

--- a/test/ex15_vector_frame.d3b
+++ b/test/ex15_vector_frame.d3b
@@ -1,4 +1,4 @@
-|Sx||597|
+|Sx||529|
 <stream version="3.0" type="das-basic-stream">
   <properties>
     <p name="instrument">EFI</p>
@@ -9,33 +9,34 @@
     <p name="modelLabel">FM-2</p>
     <p name="title">EFI FM2 - Level 1</p>
   </properties>
-  <frame name="TSCS" type="cartesian">
+  <frame name="TSCS" body="TS1">
     <properties>
-      <p name="label">Tracers Spocecraft Coordinate Frame</p>
+      <p name="label">Tracers Spacecraft Coordinate Frame</p>
     </properties>
-    <dir name="x"/>
-	  <dir name="y"/>
-	  <dir name="z"/>    
   </frame>
 </stream>
-|Hx|80|832|
+|Hx|80|915|
 <dataset name="EAC_ROI" plot="cartesian2d" rank="1" index="*">
   <properties>
-    <p name="info">Fluxgate Magnetic Field 3-Vectors sampled at 128 Hz</p>
+    <p name="info">Electric Field, 2D-Vectors in spin plane sampled at 128 Hz</p>
     <p name="label">Magnetic Field, 128 Hz</p>
   </properties>
   
   <coord axis="x" physDim="time" >
     <properties><p name="label">UTC</p></properties>
-    <scalar use="center" semantic="datetime" index="*" units="TT2000">
+    <scalar semantic="datetime" storage="long" index="*" units="TT2000">
       <packet numItems="1" itemBytes="8" encoding="LEint" fill="-9223372036854775808"/>
     </scalar>
   </coord>
+
   <data name="EAC" physDim="E" frame="TSCS" >
-    <properties><p name="label">EFI SCI @ 128 Hz</p></properties>
-    <vector use="center" semantic="int" index="*" units="">
-      <component dir="x"/>
-      <component dir="y"/>
+    <properties>
+      <p name="label">EFI SCI @ 128 Hz</p>
+    </properties>
+    <vector semantic="int" index="*" units="" system="cartesian" components="0;1">
+      <properties>
+        <p name="label" type="stringArray">Ex Ey</p>
+      </properties>
       <packet numItems="2" itemBytes="4" encoding="LEint" fill="-2147483648"/>
     </vector>
   </data>

--- a/test/ex16_mag_grid_doc.d3x
+++ b/test/ex16_mag_grid_doc.d3x
@@ -18,7 +18,7 @@
     </p>
   </properties>
 
-  <frame name="lab601" type="cartesian">
+  <frame name="lab601">
     <properties>
       <p name="label">Room 601 Coordinates</p>
       <p name="summary">
@@ -26,10 +26,9 @@
         +Y is towards the north wall.  Zero is at the inner southwest corner.
       </p>
     </properties>
-    <dir name="X_601" /><dir name="Y_601" /><dir name="Z_601" />
   </frame>
 
-  <frame name="sensor" type="cartesian">
+  <frame name="sensor">
     <properties>
       <p name="label">Intrinsic VMR sensor coords</p>
       <p name="summary">
@@ -38,7 +37,6 @@
         location index (2nd array shape parameter)
       </p>
     </properties>
-    <dir name="x" /><dir name="y" /><dir name="z" />
   </frame>
 
   <dataset name="merit_test" id="1" rank="1" index="*;4">
@@ -55,8 +53,7 @@
     <!-- display the Y direction of the room in the X plot direction just to show
          that these aren't intrinsically linked. -->
 	 <coord physDim="space" axis="y;x" frame="lab601">
-	 	<vector semantic="real" units="m" index="-;4">
-			<component dir="X_601" /><component dir="Y_601"/>
+	 	<vector semantic="real" units="m" index="-;4" system="cartesian" components="1;0">
 			<values>1 1 2 1 1 2 2 2</values>
 		</vector>
 	 </coord>
@@ -67,8 +64,7 @@
         <p name="componentLabel" type="stringArray">Bx_cal By_cal Bz_cal</p>
       </properties>
       
-      <vector use="center" semantic="real" units="nT" index="*;4">
-        <component dir="X_601"/><component dir="Y_601"/><component dir="Z_601"/>
+      <vector use="center" semantic="real" units="nT" index="*;4" system="cartesian" components="0;1;2">
         <packet numItems="12" valTerm=";"/>
       </vector>
     </data>
@@ -87,8 +83,7 @@
         </p>
       </properties>
       
-      <vector use="center" semantic="real" units="nT" index="*;4">
-        <component dir="x"/><component dir="y"/><component dir="z"/>
+      <vector use="center" semantic="real" units="nT" index="*;4" system="cartesian" components="0;1;2">
         <packet numItems="12" valTerm=";"/>
       </vector>
     </data>


### PR DESCRIPTION
Provides two basic updates:
1. Schemas work with latest vector frame and coordinate system refactoring in das2C
2. All examples have been updated to work with new das3 query returns that send both a header and a list of datasets

The commands `make`, `make test`, and `make examples` all work with latest das2C.